### PR TITLE
Update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@
 .idea
 .vscode
 config.toml
+masscan.conf
 .env

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /target
 /migrations
 .idea
+.vscode
 config.toml
 .env

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "ServerSeekerV2"
 version = "0.1.0"
-edition = "2021"
-rust-version = "1.80.0"
+edition = "2024"
+rust-version = "1.85.0"
 repository = "https://git.funtimes909.xyz/ServerSeekerV2/ServerSeekerV2"
 authors = ["Funtimes909"]
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,3 @@
-#![feature(let_chains)]
 #![feature(string_from_utf8_lossy_owned)]
 
 mod config;


### PR DESCRIPTION
* Updated the Gitignore file to ignore masscan.conf
* Updated Edition and Rust version in Cargo.toml
* Removed `#![feature(let_chains)]` as its no longer needed